### PR TITLE
Added empty description for release feed items

### DIFF
--- a/scripts/collect-releases.js
+++ b/scripts/collect-releases.js
@@ -30,7 +30,7 @@ const releases = await Promise.all(repos.map(async repo => {
 
 const relevantReleases = releases.flat().map(rel => composeFeedItem({
   title: `Released ${rel.repo} ${rel.tag_name}`,
-  description: rel.body,
+  description: "",
   pubDate: buildRFC822Date(rel.published_at),
   link: rel.html_url,
   guid: rel.html_url

--- a/scripts/collect-releases.js
+++ b/scripts/collect-releases.js
@@ -30,7 +30,7 @@ const releases = await Promise.all(repos.map(async repo => {
 
 const relevantReleases = releases.flat().map(rel => composeFeedItem({
   title: `Released ${rel.repo} ${rel.tag_name}`,
-  description: "",
+  description: '',
   pubDate: buildRFC822Date(rel.published_at),
   link: rel.html_url,
   guid: rel.html_url


### PR DESCRIPTION
### Main changes
- Added empty description for release descriptions

### Context
- Related https://github.com/UlisesGascon/poc-nodejs-news-feeder/pull/8#issuecomment-1598209928

### Changelog

- 26863f5 feat: added empty description for release feed items by @UlisesGascon
- e495cd3 chore: linting by @UlisesGascon
